### PR TITLE
Use fully-qualified image location

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,5 +4,5 @@
   description: Runs cljfmt Docker image to lint clojure files
   language: docker_image
   types: [clojure]
-  entry: allisoncasey327/cljfmt:v0.9.1
+  entry: docker.io/allisoncasey327/cljfmt:v0.9.1
   args: [fix]


### PR DESCRIPTION
This helps when using Podman-as-Docker, fixing:
Error: short-name resolution enforced but cannot prompt without a TTY